### PR TITLE
relx compatible

### DIFF
--- a/src/erlang_localtime.app.src
+++ b/src/erlang_localtime.app.src
@@ -2,6 +2,8 @@
  [
   {description, ""},
   {vsn, "1.0"},
+  {applications, [kernel, stdlib]},
+  {modules, []},
   {registered, []},
   {env, []}
  ]}.


### PR DESCRIPTION
Hello!
I suggest a small change for a compatibility with relx. Relx doesn't make a release without "modules" and "applications" directives in the .app file.
