### PR TITLE
Add missing fields for hex publish

### DIFF
--- a/src/erlang_localtime.app.src
+++ b/src/erlang_localtime.app.src
@@ -1,11 +1,12 @@
 {application, 'erlang_localtime',
  [
   {description, "Erlang library for conversion from one local time to another"},
-  {vsn, "1.0"},
+  {vsn, "1.0.0"},
   {applications, [kernel, stdlib]},
   {modules, []},
   {registered, []},
   {env, []},
+  {maintainers, ["Jesse Gumm", "Heinz N. Gies"]},
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/choptastic/erlang_localtime"}]}
  ]}.


### PR DESCRIPTION
Hi I've published erlang_localtime as a hex package, this are the changes necessary to make it hex-able with riak3. Since it is your project it would be great if you'd take over the package, for that you can ask hex.pm to change ownership, until then I'll try to keep it up to date with the latest tagged release.

For the meantime I added myself as a secondary maintainer so that people having questions regarding the package don't bother you, please remove that if you take over the package since I don't want to claim your work as mine.